### PR TITLE
feat(flake): add flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+result
+debug.log

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ Using Flake:
 {
   environment.systemPackages = with pkgs; [
     inputs.curd.packages."x86_64-linux".curd
-    mpv # Required for Curd to work
   ];
 }
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,43 @@ curd
 </details>
 
 <details>
+<summary>NixOS Installation</summary>
+
+Using Flake:
+
+```nix
+/* flake.nix*/
+{
+  description = "Nixos Flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    curd.url = "github:Wraient/curd";
+
+  };
+
+  /* ... */
+}
+
+```
+
+```nix
+
+/* configuration.nix */
+{ inputs, pkgs, ... }:
+{
+  environment.systemPackages = with pkgs; [
+    inputs.curd.packages."x86_64-linux".curd
+    mpv # Required for Curd to work
+  ];
+}
+
+```
+
+
+</details>
+
+<details>
 <summary>Generic Installation</summary>
 
 ```bash
@@ -207,7 +244,7 @@ config file is located at ```~/.config/curd/curd.conf```
 - mpv - Video player (vlc support might be added later)
 - rofi - Selection menu
 - ueberzug - Display images in rofi
-    
+
 ## API Used
 - [Anilist API](https://anilist.gitbook.io/anilist-apiv2-docs) - Update user data and download user data
 - [AniSkip API](https://api.aniskip.com/api-docs) - Get anime intro and outro timings

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1737110817,
+        "narHash": "sha256-DSenga8XjPaUV5KUFW/i3rNkN7jm9XmguW+qQ1ZJTR4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "041c867bad68dfe34b78b2813028a2e2ea70a23c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,30 +1,31 @@
 {
   description = "Curd Flake";
-
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-
   outputs = { self, nixpkgs }: {
-    packages.x86_64-linux.curd = let
+    packages.x86_64-linux = let
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    in pkgs.stdenv.mkDerivation {
-      pname = "curd";
-      version = "latest";
-
-      src = pkgs.fetchurl {
-        url = "https://github.com/Wraient/curd/releases/latest/download/curd";
-        sha256 = "1rkdy6p13i4213hhx7s08ix75in0xjpfvpxcsbjrpdlr14kc044s";
-      };
-
-      phases = [ "installPhase" ];
-      installPhase = ''
-        install -Dm755 $src $out/bin/curd
-      '';
-
-      meta = with pkgs.lib; {
-        description = "Watch anime in CLI with AniList Tracking, Discord RPC, Intro/Outro/Filler/Recap Skipping, etc";
-        homepage = "https://github.com/Wraient/curd";
-        license = licenses.gpl3;
-        platforms = platforms.linux;
+    in {
+      curd = pkgs.stdenv.mkDerivation {
+        pname = "curd";
+        version = "1.0.5";
+        src = pkgs.fetchurl {
+          url = "https://github.com/Wraient/curd/releases/download/v1.0.5/curd";
+          sha256 = "1rkdy6p13i4213hhx7s08ix75in0xjpfvpxcsbjrpdlr14kc044s";
+        };
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+        buildInputs = [ pkgs.mpv ];
+        phases = ["installPhase"];
+        installPhase = ''
+          install -Dm755 $src $out/bin/curd
+          wrapProgram $out/bin/curd \
+            --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.mpv ]}
+        '';
+        meta = with pkgs.lib; {
+          description = "Watch anime in CLI with AniList Tracking, Discord RPC, Intro/Outro/Filler/Recap Skipping, etc";
+          homepage = "https://github.com/Wraient/curd";
+          license = licenses.gpl3;
+          platforms = platforms.linux;
+        };
       };
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -1,32 +1,65 @@
 {
-  description = "Curd Flake";
+  description = "A CLI anime streaming tool with AniList integration";
+
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  outputs = { self, nixpkgs }: {
-    packages.x86_64-linux = let
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+
+  outputs = { self, nixpkgs }: 
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      
+      # Helper function to generate attrsets for multiple systems
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      
+      # Helper function to get pkgs for each system
+      pkgsFor = system: import nixpkgs { inherit system; };
+      
     in {
-      curd = pkgs.stdenv.mkDerivation {
-        pname = "curd";
-        version = "1.0.5";
-        src = pkgs.fetchurl {
-          url = "https://github.com/Wraient/curd/releases/download/v1.0.5/curd";
-          sha256 = "1rkdy6p13i4213hhx7s08ix75in0xjpfvpxcsbjrpdlr14kc044s";
+      packages = forAllSystems (system: let 
+        pkgs = pkgsFor system;
+      in {
+        default = self.packages.${system}.curd;  # Default Package
+        
+        curd = pkgs.stdenv.mkDerivation rec {
+          pname = "curd";
+          version = "1.0.5";
+          
+          src = pkgs.fetchurl {
+            url = "https://github.com/Wraient/curd/releases/download/v${version}/curd";
+            sha256 = "1rkdy6p13i4213hhx7s08ix75in0xjpfvpxcsbjrpdlr14kc044s";
+          };
+
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+          
+          buildInputs = with pkgs; [ 
+            mpv 
+            ueberzugpp
+            rofi
+          ];
+
+          phases = ["installPhase"];
+          
+          installPhase = ''
+            install -Dm755 $src $out/bin/curd
+            wrapProgram $out/bin/curd \
+              --prefix PATH : ${pkgs.lib.makeBinPath buildInputs}
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Watch anime in CLI with AniList Tracking, Discord RPC, and automatic intro/outro skipping";
+            homepage = "https://github.com/Wraient/curd";
+            license = licenses.gpl3;
+            platforms = platforms.linux;
+            mainProgram = "curd";
+          };
         };
-        nativeBuildInputs = [ pkgs.makeWrapper ];
-        buildInputs = [ pkgs.mpv ];
-        phases = ["installPhase"];
-        installPhase = ''
-          install -Dm755 $src $out/bin/curd
-          wrapProgram $out/bin/curd \
-            --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.mpv ]}
-        '';
-        meta = with pkgs.lib; {
-          description = "Watch anime in CLI with AniList Tracking, Discord RPC, Intro/Outro/Filler/Recap Skipping, etc";
-          homepage = "https://github.com/Wraient/curd";
-          license = licenses.gpl3;
-          platforms = platforms.linux;
+      });
+
+      # Add apps to allow use with `nix run`
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.curd}/bin/curd";
         };
-      };
+      });
     };
-  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "Curd Flake";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }: {
+    packages.x86_64-linux.curd = let
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    in pkgs.stdenv.mkDerivation {
+      pname = "curd";
+      version = "latest";
+
+      src = pkgs.fetchurl {
+        url = "https://github.com/Wraient/curd/releases/latest/download/curd";
+        sha256 = "1rkdy6p13i4213hhx7s08ix75in0xjpfvpxcsbjrpdlr14kc044s";
+      };
+
+      phases = [ "installPhase" ];
+      installPhase = ''
+        install -Dm755 $src $out/bin/curd
+      '';
+
+      meta = with pkgs.lib; {
+        description = "Watch anime in CLI with AniList Tracking, Discord RPC, Intro/Outro/Filler/Recap Skipping, etc";
+        homepage = "https://github.com/Wraient/curd";
+        license = licenses.gpl3;
+        platforms = platforms.linux;
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Added flake for installation on NixOS

This PR introduces a flake to simplify the installation of **Curd** on NixOS. The flake fetches the latest release of Curd from its official GitHub repository and integrates it into the Nix package system.

**Main Changes:**

    Added a flake with support for x86_64-linux.
    Fetches the latest release of Curd and installs it as a binary under $out/bin/curd.
    Basic documentation provided to guide users on how to use the flake.