### PR TITLE
fix: Use nano if vim unavailable when -e flag set

### DIFF
--- a/internal/curd.go
+++ b/internal/curd.go
@@ -44,7 +44,11 @@ func EditConfig(configFilePath string) {
 				editor = "notepad.exe"
 			}
 		} else {
-			editor = "vim"
+			if _, err := exec.LookPath("vim"); err == nil {
+				editor = "vim"
+			} else {
+				editor = "nano"
+			}
 		}
 	}
 


### PR DESCRIPTION
In linux, if vim wasn't installed, -e flag would do nothing. Thus, if vim unavailable, uses nano instead (which is more common ig?)