### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Run `curd` with the following options:
 curd [options]
 ```
 
-### Arugments would always take precendence over configuration
+### Arguments would always take precedence over configuration
 
 > **Note**:
 > - To use rofi you need rofi and ueberzug installed.

--- a/internal/anime_list.go
+++ b/internal/anime_list.go
@@ -57,8 +57,8 @@ func SearchAnime(query, mode string) (map[string]string, error) {
 
 	// Prepare the anime list
 	animeList := make(map[string]string)
-	
-	searchGql := `query($search: SearchInput, $limit: Int, $page: Int, $translationType: VaildTranslationTypeEnumType, $countryOrigin: VaildCountryOriginEnumType) {
+
+	searchGql := `query($search: SearchInput, $limit: Int, $page: Int, $translationType: ValidTranslationTypeEnumType, $countryOrigin: ValidCountryOriginEnumType) {
 		shows(search: $search, limit: $limit, page: $page, translationType: $translationType, countryOrigin: $countryOrigin) {
 			edges {
 				_id
@@ -139,13 +139,13 @@ func SearchAnime(query, mode string) (map[string]string, error) {
 				episodesStr = "Unknown"
 			}
 		}
-		
+
 		// Use English name if available and configured, otherwise use default name
 		displayName := anime.Name
 		if anime.EnglishName != "" && userCurdConfig.AnimeNameLanguage == "english" {
 			displayName = anime.EnglishName
 		}
-		
+
 		animeList[anime.ID] = fmt.Sprintf("%s (%s episodes)", displayName, episodesStr)
 	}
 	return animeList, nil

--- a/internal/curd.go
+++ b/internal/curd.go
@@ -153,7 +153,7 @@ func ExitCurd(err error) {
 	CurdOut("Have a great day!")
 	// If the error is not about the connection refused, print the error
 	if err != nil && !strings.Contains(err.Error(), "dial unix "+anime.Ep.Player.SocketPath+": connect: connection refused") {
-		CurdOut(fmt.Sprintf("Erorr: %v", err))
+		CurdOut(fmt.Sprintf("Error: %v", err))
 		if runtime.GOOS == "windows" {
 			fmt.Println("Press Enter to exit")
 			var wait string

--- a/internal/episode_url.go
+++ b/internal/episode_url.go
@@ -112,7 +112,7 @@ func extractLinks(provider_id string) map[string]interface{} {
 // - []string: a list of links for specified episode.
 // - error: an error if the episode is not found or if there is an issue during the search.
 func GetEpisodeURL(config CurdConfig, id string, epNo int) ([]string, error) {
-	query := `query($showId:String!,$translationType:VaildTranslationTypeEnumType!,$episodeString:String!){episode(showId:$showId,translationType:$translationType,episodeString:$episodeString){episodeString sourceUrls}}`
+	query := `query($showId:String!,$translationType:ValidTranslationTypeEnumType!,$episodeString:String!){episode(showId:$showId,translationType:$translationType,episodeString:$episodeString){episodeString sourceUrls}}`
 
 	variables := map[string]string{
 		"showId":          id,
@@ -183,7 +183,7 @@ func GetEpisodeURL(config CurdConfig, id string, epNo int) ([]string, error) {
 	if highestPriorityURL != "" {
 		validURLs = []string{highestPriorityURL}
 	}
-	
+
 	if len(validURLs) == 0 {
 		return nil, fmt.Errorf("no valid source URLs found in response")
 	}


### PR DESCRIPTION
Found via `codespell -S vendor -L skiped` and `typos README.md internal`