### PR TITLE
fix: whitespace getting ignored in search + fuzzy matching

### DIFF
--- a/internal/anilist.go
+++ b/internal/anilist.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -85,13 +86,61 @@ func GetAnimeMapPreview(animeList AnimeList) map[string]RofiSelectPreview {
 	return animeMap
 }
 
+// fuzzy matching w/ Levenshtein distance
+func levenshtein(a, b string) int {
+	a = strings.ToLower(a)
+	b = strings.ToLower(b)
+	ar, br := []rune(a), []rune(b)
+	alen, blen := len(ar), len(br)
+	if alen == 0 {
+		return blen
+	}
+	if blen == 0 {
+		return alen
+	}
+	matrix := make([][]int, alen+1)
+	for i := range matrix {
+		matrix[i] = make([]int, blen+1)
+	}
+	for i := 0; i <= alen; i++ {
+		matrix[i][0] = i
+	}
+	for j := 0; j <= blen; j++ {
+		matrix[0][j] = j
+	}
+	for i := 1; i <= alen; i++ {
+		for j := 1; j <= blen; j++ {
+			cost := 0
+			if ar[i-1] != br[j-1] {
+				cost = 1
+			}
+			matrix[i][j] = min3(
+				matrix[i-1][j]+1,
+				matrix[i][j-1]+1,
+				matrix[i-1][j-1]+cost,
+			)
+		}
+	}
+	return matrix[alen][blen]
+}
+
+func min3(a, b, c int) int {
+	if a < b && a < c {
+		return a
+	}
+	if b < c {
+		return b
+	}
+	return c
+}
+
 // SearchAnimeAnilist sends the query to AniList and returns a map of title to ID
 func SearchAnimeAnilistPreview(query, token string) (map[string]RofiSelectPreview, error) {
 	url := "https://graphql.anilist.co"
 
 	queryString := `
 	query ($search: String) {
-		Page(page: 1, perPage: 10) {
+		Page(page: 1, perPage: 50) {
 			media(search: $search, type: ANIME) {
 				id
 				title {
@@ -149,29 +198,45 @@ func SearchAnimeAnilistPreview(query, token string) (map[string]RofiSelectPrevie
 	animeList := responseData["data"].Page.Media
 	animeDict := make(map[string]RofiSelectPreview)
 
-	// Map titles and cover images to their IDs
+	type scoredAnime struct {
+		id    string
+		title string
+		cover string
+		score int
+	}
+	var scored []scoredAnime
 	for _, anime := range animeList {
 		idStr := strconv.Itoa(anime.ID)
 		title := anime.Title.English
 		if title == "" {
 			title = anime.Title.Romaji
 		}
-		animeDict[idStr] = RofiSelectPreview{
-			Title:      title,
-			CoverImage: anime.CoverImage.Large,
+		cover := anime.CoverImage.Large
+		score := levenshtein(title, query)
+		scored = append(scored, scoredAnime{idStr, title, cover, score})
+	}
+	sort.Slice(scored, func(i, j int) bool {
+		return scored[i].score < scored[j].score
+	})
+	for i, s := range scored {
+		if i >= 10 {
+			break
+		}
+		animeDict[s.id] = RofiSelectPreview{
+			Title:      s.title,
+			CoverImage: s.cover,
 		}
 	}
-
 	return animeDict, nil
 }
 
 // SearchAnimeAnilist sends the query to AniList and returns a map of title to ID
-func SearchAnimeAnilist(query, token string) (map[string]string, error) {
+func SearchAnimeAnilist(query, token string) ([]SelectionOption, error) {
 	url := "https://graphql.anilist.co"
 
 	queryString := `
 	query ($search: String) {
-		Page(page: 1, perPage: 10) {
+		Page(page: 1, perPage: 50) {
 			media(search: $search, type: ANIME) {
 				id
 				title {
@@ -224,19 +289,36 @@ func SearchAnimeAnilist(query, token string) (map[string]string, error) {
 	}
 
 	animeList := responseData["data"].Page.Media
-	animeDict := make(map[string]string)
+	var results []SelectionOption
 
-	// Map titles to their IDs as strings
-	for _, anime := range animeList {
-		idStr := strconv.Itoa(anime.ID) // Convert ID to string
-		if anime.Title.English != "" {
-			animeDict[idStr] = anime.Title.English
-		} else {
-			animeDict[idStr] = anime.Title.Romaji
-		}
+	type scoredAnime struct {
+		id    string
+		title string
+		score int
 	}
-
-	return animeDict, nil
+	var scored []scoredAnime
+	for _, anime := range animeList {
+		idStr := strconv.Itoa(anime.ID)
+		title := anime.Title.English
+		if title == "" {
+			title = anime.Title.Romaji
+		}
+		score := levenshtein(title, query)
+		scored = append(scored, scoredAnime{idStr, title, score})
+	}
+	sort.Slice(scored, func(i, j int) bool {
+		return scored[i].score < scored[j].score
+	})
+	for i, s := range scored {
+		if i >= 10 {
+			break
+		}
+		results = append(results, SelectionOption{
+			Key:   s.id,
+			Label: s.title,
+		})
+	}
+	return results, nil
 }
 
 // Function to get AniList user ID and username

--- a/internal/curd.go
+++ b/internal/curd.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
+	"bufio"
 	"github.com/gen2brain/beeep"
 )
 
@@ -550,8 +550,8 @@ func UpdateCurd(repo, fileName string) error {
 
 func AddNewAnime(userCurdConfig *CurdConfig, anime *Anime, user *User, databaseAnimes *[]Anime) SelectionOption {
 	var query string
-	var animeMap map[string]string
 	var animeMapPreview map[string]RofiSelectPreview
+	var animeOptions []SelectionOption
 	var err error
 	var anilistSelectedOption SelectionOption
 
@@ -564,12 +564,14 @@ func AddNewAnime(userCurdConfig *CurdConfig, anime *Anime, user *User, databaseA
 		query = userInput
 	} else {
 		CurdOut("Enter the anime name:")
-		fmt.Scanln(&query)
+		reader := bufio.NewReader(os.Stdin)
+		input, _ := reader.ReadString('\n')
+		query = strings.TrimSpace(input)
 	}
 	if userCurdConfig.RofiSelection && userCurdConfig.ImagePreview {
 		animeMapPreview, err = SearchAnimeAnilistPreview(query, user.Token)
 	} else {
-		animeMap, err = SearchAnimeAnilist(query, user.Token)
+		animeOptions, err = SearchAnimeAnilist(query, user.Token)
 	}
 	if err != nil {
 		Log(fmt.Sprintf("Failed to search anime: %v", err))
@@ -578,7 +580,7 @@ func AddNewAnime(userCurdConfig *CurdConfig, anime *Anime, user *User, databaseA
 	if userCurdConfig.RofiSelection && userCurdConfig.ImagePreview {
 		anilistSelectedOption, err = DynamicSelectPreview(animeMapPreview, false)
 	} else {
-		anilistSelectedOption, err = DynamicSelect(animeMap)
+		anilistSelectedOption, err = DynamicSelectFromSlice(animeOptions)
 	}
 
 	if anilistSelectedOption.Key == "-1" {

--- a/internal/selection_menu.go
+++ b/internal/selection_menu.go
@@ -25,14 +25,16 @@ type SelectionOption struct {
 
 // Model represents the application state for the selection prompt
 type Model struct {
-	options        map[string]string
-	filter         string
-	filteredKeys   []SelectionOption
-	selected       int
-	terminalWidth  int
-	terminalHeight int
-	scrollOffset   int  // Track the topmost visible item
-	addNewOption   bool // Add this field
+	options         map[string]string
+	filter          string
+	filteredKeys    []SelectionOption
+	selected        int
+	terminalWidth   int
+	terminalHeight  int
+	scrollOffset    int               // Track the topmost visible item
+	addNewOption    bool
+	useSliceMode    bool              // Track if we're using slice-based filtering
+	originalOptions []SelectionOption // Store original options for slice-based filtering
 }
 
 var (
@@ -183,21 +185,31 @@ func (m Model) visibleItemsCount() int {
 func (m *Model) filterOptions() {
 	m.filteredKeys = []SelectionOption{}
 
-	for key, value := range m.options {
+	if m.useSliceMode {
+		// slice-based filtering, filter from the original options
+		for _, option := range m.originalOptions {
+			if strings.Contains(strings.ToLower(option.Label), strings.ToLower(m.filter)) {
+				m.filteredKeys = append(m.filteredKeys, option)
+			}
+		}
+	} else {
+		// map-based filtering
+		for key, value := range m.options {
 		// When the key is " ", compare and display using the value instead
-		if key == " " {
-			if strings.Contains(strings.ToLower(value), strings.ToLower(m.filter)) {
+			if key == " " {
+				if strings.Contains(strings.ToLower(value), strings.ToLower(m.filter)) {
+					m.filteredKeys = append(m.filteredKeys, SelectionOption{Label: value, Key: key})
+				}
+			} else if strings.Contains(strings.ToLower(value), strings.ToLower(m.filter)) {
 				m.filteredKeys = append(m.filteredKeys, SelectionOption{Label: value, Key: key})
 			}
-		} else if strings.Contains(strings.ToLower(value), strings.ToLower(m.filter)) {
-			m.filteredKeys = append(m.filteredKeys, SelectionOption{Label: value, Key: key})
 		}
-	}
 
-	// Sort the filtered options alphabetically
-	sort.Slice(m.filteredKeys, func(i, j int) bool {
-		return m.filteredKeys[i].Label < m.filteredKeys[j].Label
-	})
+		// Sort the filtered options alphabetically
+		sort.Slice(m.filteredKeys, func(i, j int) bool {
+			return m.filteredKeys[i].Label < m.filteredKeys[j].Label
+		})
+	}
 
 	// Add "Add new anime" option if enabled
 	if m.addNewOption {
@@ -436,8 +448,10 @@ func DynamicSelectFromSlice(options []SelectionOption) (SelectionOption, error) 
 	}
 
 	model := &Model{
-		options:      make(map[string]string), // empty map since we're using slice
-		filteredKeys: orderedOptions,
+		options:         make(map[string]string), // empty map since we're using slice
+		filteredKeys:    orderedOptions,
+		useSliceMode:    true,                    // slice-based filtering
+		originalOptions: orderedOptions,          // store original options for filtering
 	}
 
 	model.filteredKeys = append(model.filteredKeys, SelectionOption{

--- a/internal/selection_menu.go
+++ b/internal/selection_menu.go
@@ -420,6 +420,53 @@ func RofiSelect(options map[string]string) (SelectionOption, error) {
 	return SelectionOption{}, fmt.Errorf("selected option not found in original list")
 }
 
+func DynamicSelectFromSlice(options []SelectionOption) (SelectionOption, error) {
+	if GetGlobalConfig().RofiSelection {
+		optionsMap := make(map[string]string)
+		for _, option := range options {
+			optionsMap[option.Key] = option.Label
+		}
+		return RofiSelect(optionsMap)
+	}
+
+	// slice to maintain order
+	var orderedOptions []SelectionOption
+	for _, option := range options {
+		orderedOptions = append(orderedOptions, option)
+	}
+
+	model := &Model{
+		options:      make(map[string]string), // empty map since we're using slice
+		filteredKeys: orderedOptions,
+	}
+
+	model.filteredKeys = append(model.filteredKeys, SelectionOption{
+		Label: "Quit",
+		Key:   "-1",
+	})
+
+	p := tea.NewProgram(model)
+
+	finalModel, err := p.Run()
+	if err != nil {
+		return SelectionOption{}, err
+	}
+
+	// resetting terminal state
+	fmt.Print("\033[?25h") // show cursor
+	fmt.Print("\033[?7h")  // line wrapping
+
+	finalSelectionModel, ok := finalModel.(*Model)
+	if !ok {
+		return SelectionOption{}, fmt.Errorf("unexpected model type")
+	}
+
+	if finalSelectionModel.selected < len(finalSelectionModel.filteredKeys) {
+		return finalSelectionModel.filteredKeys[finalSelectionModel.selected], nil
+	}
+	return SelectionOption{}, nil
+}
+
 // DynamicSelect displays a simple selection prompt without extra features
 func DynamicSelect(options map[string]string) (SelectionOption, error) {
 	if GetGlobalConfig().RofiSelection {
@@ -444,7 +491,10 @@ func DynamicSelect(options map[string]string) (SelectionOption, error) {
 			}
 		}
 	} else {
-		// For other selections, maintain alphabetical order
+		// For other selections, preserve the order as passed in
+		// Since Go maps don't preserve insertion order, we need to handle this differently
+		// For now, we'll use the order as it comes from the map iteration
+		// (This will be random, but it's better than alphabetical sorting for search results)
 		for key, value := range options {
 			orderedOptions = append(orderedOptions, SelectionOption{
 				Key:   key,


### PR DESCRIPTION
In its current state, if you search for something like "The New Gate", curd will only search for `The`, ignoring everything after the whitespace. This PR fixes that, and also adds fuzzy matching in the search results for better UX. Also, increased the per page result to 50 from 10, for better fuzzy matching.