### PR TITLE
Add ctrl+p and ctrl+n vim like keybinds to menu selection

### DIFF
--- a/internal/selection_menu.go
+++ b/internal/selection_menu.go
@@ -88,7 +88,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.filter = m.filter[:len(m.filter)-1]
 				updateFilter = true
 			}
-		case "down", "tab":
+		case "down", "tab", "ctrl+n":
 			// Move the selection cursor down
 			if m.selected < len(m.filteredKeys)-1 {
 				m.selected++
@@ -98,7 +98,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.selected >= m.scrollOffset+m.visibleItemsCount() {
 				m.scrollOffset++
 			}
-		case "up", "shift+tab":
+		case "up", "shift+tab", "ctrl+p":
 			// Move the selection cursor up
 			if m.selected > 0 {
 				m.selected--


### PR DESCRIPTION
Adds ctrl+p and ctrl+n as keybinds to go up or down on the menus. This is a common shortcut in vim and many other CLI applications.