### PR TITLE
Discord RPC support for Vesktop

### DIFF
--- a/vendor/github.com/tr1xem/go-discordrpc/internal/ipc/ipc.go
+++ b/vendor/github.com/tr1xem/go-discordrpc/internal/ipc/ipc.go
@@ -15,9 +15,11 @@ type SocketInterface interface {
 
 // GetIpcPath returns the best IPC socket path for the current environment.
 func GetIpcPath() string {
+	uid := fmt.Sprintf("%d", os.Getuid())
 	candidates := []string{
-		"/run/user/1000/snap.discord",
-		"/run/user/1000/.flatpak/com.discordapp.Discord/xdg-run",
+		"/run/user/" + uid + "/.flatpak/dev.vencord.Vesktop/xdg-run",
+		"/run/user/" + uid + "/snap.discord",
+		"/run/user/" + uid + "/.flatpak/com.discordapp.Discord/xdg-run",
 	}
 
 	for _, path := range candidates {


### PR DESCRIPTION
This adds 2 things:
- **Vesktop support:** Added `/run/user/<uid>/.flatpak/dev.vencord.Vesktop/xdg-run` as a candidate path, so Discord RPC works with Vesktop (Vencord's standalone client).                                                           
- **Dynamic UID:** Replaced the hardcoded `/run/user/1000/...` paths with `os.Getuid()` so the socket is found correctly regardless of the user's UID.