### PR TITLE
fix: validate PercentageToMarkComplete range (0-100)

### DIFF
--- a/cmd/curd/main.go
+++ b/cmd/curd/main.go
@@ -93,6 +93,13 @@ func main() {
 
 	flag.Parse()
 
+	// Validate PercentageToMarkComplete range (0-100) from CLI flag
+	if userCurdConfig.PercentageToMarkComplete < 0 {
+		userCurdConfig.PercentageToMarkComplete = 0
+	} else if userCurdConfig.PercentageToMarkComplete > 100 {
+		userCurdConfig.PercentageToMarkComplete = 100
+	}
+
 	// Check version before screen clearing
 	if *versionFlag {
 		fmt.Printf("Curd version: %s\n", resolvedVersion())

--- a/internal/config.go
+++ b/internal/config.go
@@ -582,6 +582,13 @@ func PopulateConfig(configMap map[string]string) CurdConfig {
 		config.MpvArgs = parseStringArray(mpvArgs)
 	}
 
+	// Validate PercentageToMarkComplete range (0-100)
+	if config.PercentageToMarkComplete < 0 {
+		config.PercentageToMarkComplete = 0
+	} else if config.PercentageToMarkComplete > 100 {
+		config.PercentageToMarkComplete = 100
+	}
+
 	return config
 }
 


### PR DESCRIPTION
Prevents crashes from impossible values:
- Negative numbers (e.g. -50) → clamped to 0
- Values over 100 (e.g. 200) → clamped to 100
0 is allowed (marks episode instantly) and 100 is allowed (must watch fully).